### PR TITLE
Update Makefile to use more compatible syntax

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,9 @@ LICENSEDIR?=$(PREFIX)/share/doc/ereandel
 
 install:
 	mkdir -p $(BINDIR) $(DOCDIR) $(LICENSEDIR) $(MANDIR)
-	install -m +rx ereandel -t $(BINDIR)
-	install -m +r README.md CONTRIBUTING.md -t $(DOCDIR)
-	install -m +r LICENSE -t $(LICENSEDIR)
+	install -m +rx ereandel $(BINDIR)/
+	install -m +r README.md CONTRIBUTING.md $(DOCDIR)/
+	install -m +r LICENSE $(LICENSEDIR)/
 	install -m +r ereandel.en.1 $(MANDIR)/ereandel.1
 
 uninstall:


### PR DESCRIPTION
Some versions of `make` do not support the `-t` option in Makefiles. As a result, `make install` fails on [Chimera Linux](https://chimera-linux.org/), using their GNU Make [package](https://pkgs.chimera-linux.org/package/current/main/x86_64/gmake). The `install SOURCE DESTINATION` syntax is more widely supported, as far as I am aware. With this change, `make install` runs without issue and application works as expected on Chimera Linux. I was also able to confirm that there is no regression on Ubuntu 24.04.1 LTS.